### PR TITLE
installing a pyrsistent version that works on python 2

### DIFF
--- a/self-hosting/prepare-system/ubuntu/prepare.sh
+++ b/self-hosting/prepare-system/ubuntu/prepare.sh
@@ -14,6 +14,7 @@ sudo apt install -y docker.io
 
 # Install pip and install docker-compose using pip
 sudo apt-get install -y python-pip
+sudo pip install pyrsistent==0.16.1
 sudo pip install docker-compose
 
 # Add the medic user


### PR DESCRIPTION
This blocks installing docker-compose in a python2 environment. 