### PR TITLE
use curl to get docker compose file, exclude IDE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Jet Brains IDE
+.idea

--- a/self-hosting/prepare-system/ubuntu/prepare.sh
+++ b/self-hosting/prepare-system/ubuntu/prepare.sh
@@ -21,7 +21,8 @@ sudo pip install docker-compose
 sudo useradd -d /home/medic -m medic
 sudo mkdir -p /home/medic/self-hosting/main
 
-sudo cp ../../main/docker-compose.yml /home/medic/self-hosting/main/
+sudo curl -s https://raw.githubusercontent.com/medic/cht-core/master/docker-compose.yml \
+  -o /home/medic/self-hosting/main/docker-compose.yml
 
 HA_FILE=/srv/storage/medic-core/passwd/admin
 if test -f "$HA_FILE"; then


### PR DESCRIPTION
With the changes made in #10, we can't just run a `cp` to get the `docker-compose.yml` file - we need to fetch it from cht-core repo on GH.  This PR fixes that.

It also excludes JetBrains IDE files in the `.gitignore` file