### PR TITLE
Update how we start docker

### DIFF
--- a/self-hosting/prepare-system/ubuntu/supervisor.conf
+++ b/self-hosting/prepare-system/ubuntu/supervisor.conf
@@ -1,13 +1,13 @@
 
 [program: medic]
 process_name=%(program_name)s
-command=sudo /usr/local/bin/docker-compose -f /home/medic/self-hosting/main/docker-compose.yml up -d
+command=sudo /usr/local/bin/docker-compose -f /home/medic/self-hosting/main/docker-compose.yml up
 directory=/home/medic/self-hosting/
 user=medic
 numprocs=1
 autostart=true
 autorestart=true
-stdout_logfile=/var/log/medic/medic.log
+stdout_logfile=/dev/null
 redirect_stderr=true
 stderr_logfile=/var/log/medic/medic-error.log
 startsecs=10

--- a/self-hosting/prepare-system/ubuntu/supervisor.conf
+++ b/self-hosting/prepare-system/ubuntu/supervisor.conf
@@ -1,7 +1,7 @@
 
 [program: medic]
 process_name=%(program_name)s
-command=sudo /usr/local/bin/docker-compose -f /home/medic/self-hosting/main/docker-compose.yml up
+command=sudo /usr/local/bin/docker-compose -f /home/medic/self-hosting/main/docker-compose.yml up -d
 directory=/home/medic/self-hosting/
 user=medic
 numprocs=1


### PR DESCRIPTION
Not starting docker in detached mode create double logs because all stdout messages are now sent to the supervisorctl log as well. This unnecessarily bloats the the ebs volume.